### PR TITLE
Correcting string comparison operator

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -149,7 +149,7 @@ start_adb() {
 }
 
 phone_plugged() {
-    start_adb && test "$("$ADB" $ADB_FLAGS get-state)" == "device"
+    start_adb && test "$("$ADB" $ADB_FLAGS get-state)" = "device"
 }
 
 url_reachable() {


### PR DESCRIPTION
== is only valid in a limited set of shells.
