### PR TITLE
Disable 'http_proxy' for accessing WIFI_IP on a proxy network

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -245,11 +245,12 @@ url_reachable() {
         # has it in its core, so we don't need to check that case)
         sudo apt-get install -y curl
     fi
+
+    CURL_OPTIONS=""
     if [ $DISABLE_PROXY = 1 ]; then
-        curl --noproxy '*' -m 5 -sI "$1" >/dev/null
-    else
-        curl -m 5 -sI "$1" >/dev/null
+        CURL_OPTIONS="--noproxy $WIFI_IP"
     fi
+    curl $CURL_OPTIONS -m 5 -sI "$1" >/dev/null
 }
 
 send_intent() {
@@ -536,7 +537,6 @@ fi
 
 if [ $DISABLE_PROXY = 1 ]; then
     # Disabling proxy to access WIFI_IP viz. on local network
-    temp_http_proxy=$http_proxy
     unset http_proxy
 fi
 
@@ -566,11 +566,6 @@ kill $GSTLAUNCH_PID > /dev/null 2>&1 || echo ""
 pactl set-default-source ${DEFAULT_SOURCE}
 pactl unload-module ${ECANCEL_ID}
 pactl unload-module ${SINK_ID}
-
-if [ $DISABLE_PROXY = 1 ]; then
-    # Renabling proxy on completion of the script
-    export http_proxy=$temp_http_proxy
-fi
 
 echo "Disconnected from IP Webcam. Have a nice day!"
 # idea: capture ctrl-c signal and set default source back

--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -181,7 +181,7 @@ CAPTURE_STREAM=av
 has_kernel_module() {
     # Checks if module exists in system (but does not load it)
     MODULE="$1"
-    if lsmod | grep "$MODULE" >/dev/null 2>/dev/null; then
+    if lsmod | grep -w "$MODULE" >/dev/null 2>/dev/null; then
         # echo "$MODULE is loaded! So it exists."
         return 0
     else
@@ -359,7 +359,7 @@ if ! has_kernel_module v4l2loopback; then
 fi
 
 # Probe module if not probed yet
-if lsmod | grep v4l2loopback >/dev/null 2>/dev/null; then
+if lsmod | grep -w v4l2loopback >/dev/null 2>/dev/null; then
     # module is already loaded, do nothing
     :
 elif [ $CAPTURE_STREAM = v -o $CAPTURE_STREAM = av ]; then

--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -154,6 +154,10 @@ WIFI_IP=192.168.2.140
 # Port on which IP Webcam is listening
 PORT=8080
 
+# To disable proxy while acessing WIFI_IP (set value 1 to disable, 0 for not)
+# For cases when host m/c is connected to a Proxy-Server and WIFI_IP belongs to local network
+DISABLE_PROXY=0
+
 # Dimensions of video
 WIDTH=640
 HEIGHT=480
@@ -241,7 +245,11 @@ url_reachable() {
         # has it in its core, so we don't need to check that case)
         sudo apt-get install -y curl
     fi
-    curl -m 5 -sI "$1" >/dev/null
+    if [ $DISABLE_PROXY = 1 ]; then
+        curl --noproxy '*' -m 5 -sI "$1" >/dev/null
+    else
+        curl -m 5 -sI "$1" >/dev/null
+    fi
 }
 
 send_intent() {
@@ -526,6 +534,12 @@ fi
 
 # echo "$PIPELINE"
 
+if [ $DISABLE_PROXY = 1 ]; then
+    # Disabling proxy to access WIFI_IP viz. on local network
+    temp_http_proxy=$http_proxy
+    unset http_proxy
+fi
+
 "$GSTLAUNCH" -e -vt --gst-plugin-spew \
              --gst-debug="$GST_DEBUG" \
    $PIPELINE \
@@ -552,6 +566,11 @@ kill $GSTLAUNCH_PID > /dev/null 2>&1 || echo ""
 pactl set-default-source ${DEFAULT_SOURCE}
 pactl unload-module ${ECANCEL_ID}
 pactl unload-module ${SINK_ID}
+
+if [ $DISABLE_PROXY = 1 ]; then
+    # Renabling proxy on completion of the script
+    export http_proxy=$temp_http_proxy
+fi
 
 echo "Disconnected from IP Webcam. Have a nice day!"
 # idea: capture ctrl-c signal and set default source back


### PR DESCRIPTION
Instances when `WIFI_IP` is being accessed :

1. `url_reachable` tries to `curl`on the media urls ( i.e. acessing `WIFI_IP` )

`curl` provides `--noproxy 'ip-address'` to disable proxy while accessing `ip-address`

2. `souphttpsrc` while extracting `videofeed` and `audio`

> _"http_proxy" environment variable is set, its value is used._

_quoted from [souphttpsrc](https://stuff.mit.edu/afs/athena/system/amd64_deb50/os/usr/share/gtk-doc/html/gst-plugins-good-plugins-0.10/gst-plugins-good-plugins-souphttpsrc.html)_ 

`souphttpsrc` is used by the script on `http` urls, thus doing `unset http_proxy` works.
`http_proxy` is reverted back to default value (value before the script starts) at the end of the script.