### PR TITLE
Fixed distribution checking logic, and added check for arch linux. 

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -295,6 +295,9 @@ module_id_by_sourcename() {
 if can_run lsb_release; then
     DIST=`lsb_release -i | cut -f2 -d ":"`
     RELEASE=`lsb_release -r | cut -f2 -d ":"`
+elif [ -f "/etc/arch-release" ]; then
+    DIST="Arch"
+    RELASE=""
 elif [ -f /etc/debian_version ] ; then
     DIST="Debian"
     RELEASE=`perl -ne 'chomp; if(m:(jessie|testing|sid):){print "8.0"}elsif(m:[\d\.]+:){print}else{print "0.0"}' < /etc/debian_version`
@@ -315,9 +318,9 @@ GST_1_0_AUDIO_FORMAT="format=S16LE"
 GST_0_10_VIDEO_MIMETYPE=$GST_VIDEO_MIMETYPE
 GST_0_10_VIDEO_FORMAT=$GST_VIDEO_FORMAT
 
-if [ $DIST = "Debian" -a `echo "$RELEASE >= 8.0"   | bc` -eq 1 ] ||\
-   [ $DIST = "Ubuntu" -a `echo "$RELEASE >= 14.04" | bc` -eq 1 ] ||\
-   [ $DIST = "LinuxMint" -a `echo "$RELEASE >= 14.04" | bc` -eq 1 ] ||\
+if [ $DIST = "Debian" ] && [ `echo "$RELEASE >= 8.0"   | bc` -eq 1 ] ||\
+   [ $DIST = "Ubuntu" ] && [ `echo "$RELEASE >= 14.04" | bc` -eq 1 ] ||\
+   [ $DIST = "LinuxMint" ] && [ `echo "$RELEASE >= 14.04" | bc` -eq 1 ] ||\
    [ $DIST = "Arch" ]
 then
     GST_VER="1.0"

--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -236,7 +236,7 @@ start_adb() {
 }
 
 phone_plugged() {
-    test "$("$ADB" $ADB_FLAGS get-state)" = "device"
+    test "$("$ADB" $ADB_FLAGS get-state 2>/dev/null)" = "device"
 }
 
 url_reachable() {


### PR DESCRIPTION
The section to check the linux distribution was giving me the following error on my Arch Linux machine:

`(standard_in)` 1: syntax error
./prepare-videochat.sh: line 318: [: too many arguments
(standard_in) 1: syntax error
./prepare-videochat.sh: line 319: [: too many arguments
(standard_in) 1: syntax error
./prepare-videochat.sh: line 320: [: too many arguments
./prepare-videochat.sh: line 321: [: =: unary operator expected
./prepare-videochat.sh: line 386: [: =: unary operator expected
./prepare-videochat.sh: line 386: [: =: unary operator expected
./prepare-videochat.sh: line 388: [: =: unary operator expected
Failure: Module initialization failed`

I restructured the if statement and also added a check so Arch would get detected as the running distribution.

