### PR TITLE
Fix minor typo relase -> release

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -297,7 +297,7 @@ if can_run lsb_release; then
     RELEASE=`lsb_release -r | cut -f2 -d ":"`
 elif [ -f "/etc/arch-release" ]; then
     DIST="Arch"
-    RELASE=""
+    RELEASE=""
 elif [ -f /etc/debian_version ] ; then
     DIST="Debian"
     RELEASE=`perl -ne 'chomp; if(m:(jessie|testing|sid):){print "8.0"}elsif(m:[\d\.]+:){print}else{print "0.0"}' < /etc/debian_version`


### PR DESCRIPTION
## In brief
* Fix typo of `RELASE` → `RELEASE` when detecting Arch Linux
  * Avoids variable-not-defined issues with [Bash strict checking `set -u`](http://redsymbol.net/articles/unofficial-bash-strict-mode/ )
  * When on Arch, it's not currently used by the script, but that might change in the future