### PR TITLE
Arch puts some modules files in sub directories, function has_kernel_m…

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -196,7 +196,10 @@ has_kernel_module() {
     else
        # Determining kernel object existence
        # I do not know why, but using -q in egrep makes it always return 1, so do not use it
-       if [ `find /lib/modules/$(uname -r)/ -name "$MODULE.ko" | egrep '.*'` ]; then
+       if [ 
+	`find /lib/modules/$(uname -r)/ -name "$MODULE.ko.*" | egrep '.*' || 
+	find /lib/modules/$(uname -r)/extra -name "$MODULE.ko.*" | egrep '.*'||
+	find /lib/modules/$(uname -r)/extramodules -name "$MODULE.ko.*" | egrep '.*'` ]; then
         return 0
        else
         return 1


### PR DESCRIPTION
Arch or at least my Arch puts the v412loopback module files in /lib/module/$(uname -r)/extra. Before this the code showed the error 'couldn't install using apt-get ...' and exited.