### PR TITLE
Add Android SDK root environment variable check

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -137,6 +137,10 @@ fi
 ADB_PATH=~/bin/android-sdk-linux_x86/platform-tools/adb
 if which adb > /dev/null ; then
     ADB=$(which adb)
+elif [ -f $ANDROID_SDK_ROOT/platform-tools/adb ] ; then
+    ADB=$ANDROID_SDK_ROOT/platform-tools/adb
+elif [ -f $ANDROID_HOME/platform-tools/adb ] ; then
+    ADB=$ANDROID_HOME/platform-tools/adb
 else
     ADB=$ADB_PATH
 fi


### PR DESCRIPTION
In case of using ANDROID_SDK_ROOT or ANDROID_HOME environment variable, so it needs to check those too.