### PR TITLE
Fix bug that doesn't show error when zenity is missing

### DIFF
--- a/prepare-videochat.sh
+++ b/prepare-videochat.sh
@@ -258,7 +258,8 @@ install_package() {
         echo "Trying to install $1 package."
         sudo apt-get install -y "$1"
     elif [ $DIST = "Arch" ]; then
-        error "Please install $1 package"
+        echo "Please install $1 package" 1>&2
+        exit 1
     fi
 }
 


### PR DESCRIPTION
If `zenity` package is missing the `error()` function wouldn't work as expected as it depends on `zenity` package functionality, so in `install_package()` function we should print to `stderr` and exit.