### PR TITLE
Add (partial) support for pipewire

### DIFF
--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -138,7 +138,7 @@ iw_server_is_started() {
 }
 
 module_id_by_sinkname() {
-    pacmd list-sinks | grep -e 'name:' -e 'module:' | grep -A1 "name: <$1>" | grep module: | cut -f2 -d: | tr -d ' '
+    pactl list sinks | grep -e "Name:" -e "Module:" |grep -A1 "Name: $1" | grep Module: | cut -f2 -d: | tr -d ' '
 }
 
 ### CONFIGURATION
@@ -346,13 +346,23 @@ if ! iw_server_is_started; then
     error "$MESSAGE\nPlease install and open IP Webcam in your phone and start the server.\nMake sure that values of variables IP, PORT, CAPTURE_STREAM in this script are equal with settings in IP Webcam."
 fi
 
+# Test if audio server is running on pipewire
+if pactl info | grep -q PipeWire; then
+    if [ "$CAPTURE_STREAM" = v ]; then
+        :
+    else
+    # currently setting audio sinks errors out, so give user a workaround
+        error "Only video streams on Pipewire are currently supported. Audio is a WIP. Please set CAPTURE_STREAM value to v."
+    fi
+fi
+
 if [ $CAPTURE_STREAM = a -o $CAPTURE_STREAM = av ]; then
     # idea: check if default-source is correct. If two copy of script are running,
     # then after ending first before second you will be set up with $SINK_NAME.monitor,
     # but not with your original defauld source.
     # The same issue if script was not end correctly, and you restart it.
-    DEFAULT_SINK=$(pacmd dump | grep set-default-sink | cut -f2 -d " ")
-    DEFAULT_SOURCE=$(pacmd dump | grep set-default-source | cut -f2 -d " ")
+    DEFAULT_SINK=$(pactl info | grep "Sink" | cut -f3 -d " ")
+    DEFAULT_SOURCE=$(pactl info | grep "Source" | cut -f3 -d " ")
 
     SINK_NAME="ipwebcam"
     SINK_ID=$(module_id_by_sinkname $SINK_NAME)


### PR DESCRIPTION
Pipewire-pulse recently released as a drop in replacement for pulseaudio on arch, and is on track to ship by default in fedora 34. Currently, the script does not work with pipewire due to `pacmd` being unsupported. This is fixed by getting sink names and ids with `pactl` instead.

Pulseaudio modules are also not fully implemented in pipewire yet. `module-null-sink` exists, but `module-echo-cancel` does not. However I kept getting `Failure: No such entity` when trying to implement null-sink, so a video only workaround was used for now.