### PR TITLE
Adding $ symbol on the grep search to return the correct module name

### DIFF
--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -67,7 +67,6 @@ show_help() {
     echo " -x, --no-proxy         disable proxy while acessing IP"
     echo "     --help             show this help"
 }
-
 check_os_version() {
     # checks if the OS version can use newer GStreamer version
     DIST="$1"
@@ -139,7 +138,7 @@ iw_server_is_started() {
 }
 
 module_id_by_sinkname() {
-    pactl list sinks | grep -e "Name:" -e "Module:" |grep -A1 "Name: $1" | grep Module: | cut -f2 -d: | tr -d ' '
+    pactl list sinks | grep -e "Name:" -e "Module:" |grep -A1 "Name: $1$" | grep Module: | cut -f2 -d: | tr -d ' '
 }
 
 ### CONFIGURATION


### PR DESCRIPTION
I got this warning message on line 388:
![image](https://user-images.githubusercontent.com/4330991/155354740-7bf85b95-6e9d-4013-8412-a8429dbfe56e.png)

It seems the root cause it the actual command returns all modules starting with "ipwebcam"
![image](https://user-images.githubusercontent.com/4330991/155355225-36e24e73-d765-4335-85a6-8d4fa7e35a8c.png)

To solve it, I add a $ on the grep to return only the correct module.
