### PR TITLE
Fix the if statement when checking if port select is already in use by

### DIFF
--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -67,7 +67,6 @@ show_help() {
     echo " -x, --no-proxy         disable proxy while acessing IP"
     echo "     --help             show this help"
 }
-
 check_os_version() {
     # checks if the OS version can use newer GStreamer version
     DIST="$1"
@@ -328,7 +327,8 @@ if [ -z $IP ]; then
     fi
     if ss -ln src ":$PORT" | grep -q ":$PORT"; then
         PIDOF_ADB="$(pidof adb)"
-        if test -n "$PIDOF_ADB" && ss -lptn ":$PORT" | grep "pid=${PIDOF_ADB}"; then
+        HAS_PORT_USED_BY_ADB="$(ss -lptn | grep ":$PORT" | grep "adb" | grep "pid=${PIDOF_ADB}")"
+        if test -n "$HAS_PORT_USED_BY_ADB"; then
             if confirm "Your port $PORT seems to be in use by ADB: would you like to clear the previous port before continuing?"; then
                 adb forward --remove tcp:$PORT
             else

--- a/run-videochat.sh
+++ b/run-videochat.sh
@@ -327,8 +327,7 @@ if [ -z $IP ]; then
     fi
     if ss -ln src ":$PORT" | grep -q ":$PORT"; then
         PIDOF_ADB="$(pidof adb)"
-        HAS_PORT_USED_BY_ADB="$(ss -lptn | grep ":$PORT" | grep "adb" | grep "pid=${PIDOF_ADB}")"
-        if test -n "$HAS_PORT_USED_BY_ADB"; then
+        if test -n "$PIDOF_ADB" && ss -lptn src ":$PORT" | grep -q "pid=${PIDOF_ADB}"; then
             if confirm "Your port $PORT seems to be in use by ADB: would you like to clear the previous port before continuing?"; then
                 adb forward --remove tcp:$PORT
             else


### PR DESCRIPTION
When running the script and for any reason, the ADB is using the selected port, it shows an error instead of asking to clear the previous port.
![image](https://user-images.githubusercontent.com/4330991/155356571-dc146c62-55ea-4b11-a4e3-a5ae29ba0054.png)

![image](https://user-images.githubusercontent.com/4330991/155357616-32746cc8-f1ab-4a94-a90e-e89dcad35313.png)
